### PR TITLE
Updated webpack config

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -15,7 +15,7 @@ module.exports = {
 		library: 'VX'
 	},
 	module: {
-		loaders: [
+		rules: [
 			{
 				test: /\.js$/,
 				loader: 'babel-loader',


### PR DESCRIPTION
Hi Igor,
I'm encountering the following issue when installing the package:
`configuration.module has an unknown property 'loaders'`
It looks like the name of the 'loaders' property in the webpack.config.js file changed to 'rules' in webpack 4. We would need this update in the config file as well.

For reference: https://webpack.js.org/concepts/loaders/#example

Thanks :)