### PR TITLE
Add missing hooks

### DIFF
--- a/src/VXPay/Config/VXPayPaymentHooksConfig.js
+++ b/src/VXPay/Config/VXPayPaymentHooksConfig.js
@@ -1,21 +1,27 @@
-import VXPayHooksConfig from './VXPayHooksConfig'
+import VXPayHooksConfig from './VXPayHooksConfig';
 
 class VXPayPaymentHooksConfig extends VXPayHooksConfig {
 	constructor() {
 		super();
-		this._onViewReady     = [];
-		this._onContentLoaded = [];
-		this._onClose         = [];
-		this._onSuccess       = [];
-		this._onIframeReady   = [];
-		this._onLogin         = [];
-		this._onLogout        = [];
-		this._onFlowChange    = [];
-		this._onIsLoggedIn    = [];
-		this._onTransferToken = [];
-		this._onAVSStatus     = [];
-		this._onBalance       = [];
-		this._onActiveAbos    = [];
+		this._onViewReady              = [];
+		this._onContentLoaded          = [];
+		this._onClose                  = [];
+		this._onSuccess                = [];
+		this._onIframeReady            = [];
+		this._onLogin                  = [];
+		this._onLogout                 = [];
+		this._onFlowChange             = [];
+		this._onIsLoggedIn             = [];
+		this._onTransferToken          = [];
+		this._onAVSStatus              = [];
+		this._onBalance                = [];
+		this._onActiveAbos             = [];
+		this._onPayment                = [];
+		this._onSignup                 = [];
+		this._onComfortSettingsChanged = [];
+		this._onEmailVerified          = [];
+		this._onEmailNotVerified       = [];
+		this._onPasswordChanged        = [];
 	}
 
 	/**
@@ -180,20 +186,80 @@ class VXPayPaymentHooksConfig extends VXPayHooksConfig {
 		this._onContentLoaded.push(handler);
 		return this;
 	}
+
+	/**
+	 * @param {Function} handler
+	 * @return {VXPayPaymentHooksConfig}
+	 */
+	onPayment(handler) {
+		this._onPayment.push(handler);
+		return this;
+	}
+
+	/**
+	 * @param {Function} handler
+	 * @return {VXPayPaymentHooksConfig}
+	 */
+	onSignup(handler) {
+		this._onSignup.push(handler);
+		return this;
+	}
+
+	/**
+	 * @param {Function} handler
+	 * @return {VXPayPaymentHooksConfig}
+	 */
+	onComfortSettingsChanged(handler) {
+		this._onComfortSettingsChanged.push(handler);
+		return this;
+	}
+
+	/**
+	 * @param {Function} handler
+	 * @return {VXPayPaymentHooksConfig}
+	 */
+	onEmailVerified(handler) {
+		this._onEmailVerified.push(handler);
+		return this;
+	}
+
+	/**
+	 * @param {Function} handler
+	 * @return {VXPayPaymentHooksConfig}
+	 */
+	onEmailNotVerified(handler) {
+		this._onEmailNotVerified.push(handler);
+		return this;
+	}
+
+	/**
+	 * @param {Function} handler
+	 * @return {VXPayPaymentHooksConfig}
+	 */
+	onPasswordChanged(handler) {
+		this._onPasswordChanged.push(handler);
+		return this;
+	}
 }
 
-VXPayPaymentHooksConfig.ON_VIEW_READY     = 'onViewReady';
-VXPayPaymentHooksConfig.ON_IFRAME_READY   = 'onIframeReady';
-VXPayPaymentHooksConfig.ON_CONTENT_LOADED = 'onContentLoaded';
-VXPayPaymentHooksConfig.ON_CLOSE          = 'onClose';
-VXPayPaymentHooksConfig.ON_SUCCESS        = 'onSuccess';
-VXPayPaymentHooksConfig.ON_LOGIN          = 'onLogin';
-VXPayPaymentHooksConfig.ON_LOGOUT         = 'onLogout';
-VXPayPaymentHooksConfig.ON_FLOW_CHANGE    = 'onFlowChange';
-VXPayPaymentHooksConfig.ON_IS_LOGGED_IN   = 'onIsLoggedIn';
-VXPayPaymentHooksConfig.ON_TRANSFER_TOKEN = 'onTransferToken';
-VXPayPaymentHooksConfig.ON_AVS_STATUS     = 'onAVSStatus';
-VXPayPaymentHooksConfig.ON_BALANCE        = 'onBalance';
-VXPayPaymentHooksConfig.ON_ACTIVE_ABOS    = 'onActiveAbos';
+VXPayPaymentHooksConfig.ON_VIEW_READY              = 'onViewReady';
+VXPayPaymentHooksConfig.ON_IFRAME_READY            = 'onIframeReady';
+VXPayPaymentHooksConfig.ON_CONTENT_LOADED          = 'onContentLoaded';
+VXPayPaymentHooksConfig.ON_CLOSE                   = 'onClose';
+VXPayPaymentHooksConfig.ON_SUCCESS                 = 'onSuccess';
+VXPayPaymentHooksConfig.ON_LOGIN                   = 'onLogin';
+VXPayPaymentHooksConfig.ON_LOGOUT                  = 'onLogout';
+VXPayPaymentHooksConfig.ON_FLOW_CHANGE             = 'onFlowChange';
+VXPayPaymentHooksConfig.ON_IS_LOGGED_IN            = 'onIsLoggedIn';
+VXPayPaymentHooksConfig.ON_TRANSFER_TOKEN          = 'onTransferToken';
+VXPayPaymentHooksConfig.ON_AVS_STATUS              = 'onAVSStatus';
+VXPayPaymentHooksConfig.ON_BALANCE                 = 'onBalance';
+VXPayPaymentHooksConfig.ON_ACTIVE_ABOS             = 'onActiveAbos';
+VXPayPaymentHooksConfig.ON_PAYMENT                 = 'onPayment';
+VXPayPaymentHooksConfig.ON_SIGNUP                  = 'onSignup';
+VXPayPaymentHooksConfig.ON_COMFORT_SETTINGS_CHANGE = 'onComfortSettingsChanged';
+VXPayPaymentHooksConfig.ON_EMAIL_VERIFIED          = 'onEmailVerified';
+VXPayPaymentHooksConfig.ON_EMAIL_NOT_VERIFIED      = 'onEmailNotVerified';
+VXPayPaymentHooksConfig.ON_PASSWORD_CHANGED        = 'onPasswordChanged';
 
 export default VXPayPaymentHooksConfig;

--- a/src/VXPay/Message/Hooks/VXPayHookComfortSettingsChangedMessage.js
+++ b/src/VXPay/Message/Hooks/VXPayHookComfortSettingsChangedMessage.js
@@ -1,0 +1,7 @@
+import VXPayHookMessage from './VXPayHookMessage'
+
+export default class VXPayHookComfortSettingsChangedMessage extends VXPayHookMessage {
+	constructor() {
+		super(VXPayHookMessage.HOOK_COMFORT_SETTINGS_CHANGED);
+	}
+}

--- a/src/VXPay/Message/Hooks/VXPayHookEmailNotVerifiedMessage.js
+++ b/src/VXPay/Message/Hooks/VXPayHookEmailNotVerifiedMessage.js
@@ -1,0 +1,7 @@
+import VXPayHookMessage from './VXPayHookMessage'
+
+export default class VXPayHookEmailNotVerifiedMessage extends VXPayHookMessage {
+	constructor() {
+		super(VXPayHookMessage.HOOK_EMAIL_NOT_VERIFIED);
+	}
+}

--- a/src/VXPay/Message/Hooks/VXPayHookEmailVerifiedMessage.js
+++ b/src/VXPay/Message/Hooks/VXPayHookEmailVerifiedMessage.js
@@ -1,0 +1,7 @@
+import VXPayHookMessage from './VXPayHookMessage'
+
+export default class VXPayHookEmailVerifiedMessage extends VXPayHookMessage {
+	constructor() {
+		super(VXPayHookMessage.HOOK_EMAIL_VERIFIED);
+	}
+}

--- a/src/VXPay/Message/Hooks/VXPayHookMessage.js
+++ b/src/VXPay/Message/Hooks/VXPayHookMessage.js
@@ -11,8 +11,14 @@ class VXPayHookMessage extends VXPayMessage {
 	}
 }
 
-VXPayHookMessage.HOOK_UNKNOWN      = 'dummy-unknown';
-VXPayHookMessage.HOOK_FLOW_CHANGED = 'flowChanged';
-VXPayHookMessage.HOOK_LOGIN        = 'login';
+VXPayHookMessage.HOOK_UNKNOWN                  = 'dummy-unknown';
+VXPayHookMessage.HOOK_FLOW_CHANGED             = 'flowChanged';
+VXPayHookMessage.HOOK_LOGIN                    = 'login';
+VXPayHookMessage.HOOK_PAYMENT                  = 'payment';
+VXPayHookMessage.HOOK_SIGNUP                   = 'signup';
+VXPayHookMessage.HOOK_COMFORT_SETTINGS_CHANGED = 'comfortSettingsChanged';
+VXPayHookMessage.HOOK_EMAIL_VERIFIED           = 'emailVerified';
+VXPayHookMessage.HOOK_EMAIL_NOT_VERIFIED       = 'emailNotVerified';
+VXPayHookMessage.HOOK_PASSWORD_CHANGED         = 'passwordChanged';
 
 export default VXPayHookMessage;

--- a/src/VXPay/Message/Hooks/VXPayHookMessageFactory.js
+++ b/src/VXPay/Message/Hooks/VXPayHookMessageFactory.js
@@ -1,6 +1,12 @@
-import VXPayHookMessage            from './VXPayHookMessage'
-import VXPayFlowChangedHookMessage from './VXPayFlowChangedMessage'
-import VXPayLoggedInMessage        from './VXPayLoggedInMessage'
+import VXPayHookMessage                       from './VXPayHookMessage'
+import VXPayFlowChangedHookMessage            from './VXPayFlowChangedMessage'
+import VXPayLoggedInMessage                   from './VXPayLoggedInMessage'
+import VXPayHookPaymentMessage                from './VXPayHookPaymentMessage';
+import VXPayHookSignupMessage                 from './VXPayHookSignupMessage';
+import VXPayHookComfortSettingsChangedMessage from './VXPayHookComfortSettingsChangedMessage';
+import VXPayHookEmailVerifiedMessage          from './VXPayHookEmailVerifiedMessage';
+import VXPayHookEmailNotVerifiedMessage       from './VXPayHookEmailNotVerifiedMessage';
+import VXPayHookPasswordChangedMessage        from './VXPayHookPasswordChangedMessage';
 
 export default class VXPayHookMessageFactory {
 
@@ -19,6 +25,24 @@ export default class VXPayHookMessageFactory {
 
 			case VXPayHookMessage.HOOK_LOGIN:
 				return new VXPayLoggedInMessage();
+
+			case VXPayHookMessage.HOOK_PAYMENT:
+				return new VXPayHookPaymentMessage();
+
+			case VXPayHookMessage.HOOK_SIGNUP:
+				return new VXPayHookSignupMessage();
+
+			case VXPayHookMessage.HOOK_COMFORT_SETTINGS_CHANGED:
+				return new VXPayHookComfortSettingsChangedMessage();
+
+			case VXPayHookMessage.HOOK_EMAIL_VERIFIED:
+				return new VXPayHookEmailVerifiedMessage();
+
+			case VXPayHookMessage.HOOK_EMAIL_NOT_VERIFIED:
+				return new VXPayHookEmailNotVerifiedMessage();
+
+			case VXPayHookMessage.HOOK_PASSWORD_CHANGED:
+				return new VXPayHookPasswordChangedMessage();
 
 			default:
 				return new VXPayHookMessage();

--- a/src/VXPay/Message/Hooks/VXPayHookPasswordChangedMessage.js
+++ b/src/VXPay/Message/Hooks/VXPayHookPasswordChangedMessage.js
@@ -1,0 +1,7 @@
+import VXPayHookMessage from './VXPayHookMessage'
+
+export default class VXPayHookPasswordChangedMessage extends VXPayHookMessage {
+	constructor() {
+		super(VXPayHookMessage.HOOK_PASSWORD_CHANGED);
+	}
+}

--- a/src/VXPay/Message/Hooks/VXPayHookPaymentMessage.js
+++ b/src/VXPay/Message/Hooks/VXPayHookPaymentMessage.js
@@ -1,0 +1,7 @@
+import VXPayHookMessage from './VXPayHookMessage'
+
+export default class VXPayHookPaymentMessage extends VXPayHookMessage {
+	constructor() {
+		super(VXPayHookMessage.HOOK_PAYMENT);
+	}
+}

--- a/src/VXPay/Message/Hooks/VXPayHookRouter.js
+++ b/src/VXPay/Message/Hooks/VXPayHookRouter.js
@@ -64,6 +64,24 @@ const VXPayHookRouter = (hooks, event) => {
 
 				case VXPayHookMessage.HOOK_FLOW_CHANGED:
 					return hooks.trigger(VXPayPaymentHooksConfig.ON_FLOW_CHANGE, [message]);
+
+				case VXPayHookMessage.HOOK_PAYMENT:
+					return hooks.trigger(VXPayPaymentHooksConfig.ON_PAYMENT, [message]);
+
+				case VXPayHookMessage.HOOK_SIGNUP:
+					return hooks.trigger(VXPayPaymentHooksConfig.ON_SIGNUP, [message]);
+
+				case VXPayHookMessage.HOOK_COMFORT_SETTINGS_CHANGED:
+					return hooks.trigger(VXPayPaymentHooksConfig.ON_COMFORT_SETTINGS_CHANGE, [message]);
+
+				case VXPayHookMessage.HOOK_EMAIL_VERIFIED:
+					return hooks.trigger(VXPayPaymentHooksConfig.ON_EMAIL_VERIFIED, [message]);
+
+				case VXPayHookMessage.HOOK_EMAIL_NOT_VERIFIED:
+					return hooks.trigger(VXPayPaymentHooksConfig.ON_EMAIL_NOT_VERIFIED, [message]);
+
+				case VXPayHookMessage.HOOK_PASSWORD_CHANGED:
+					return hooks.trigger(VXPayPaymentHooksConfig.ON_PASSWORD_CHANGED, [message]);
 			}
 	}
 };

--- a/src/VXPay/Message/Hooks/VXPayHookSignupMessage.js
+++ b/src/VXPay/Message/Hooks/VXPayHookSignupMessage.js
@@ -1,0 +1,7 @@
+import VXPayHookMessage from './VXPayHookMessage'
+
+export default class VXPayHookSignupMessage extends VXPayHookMessage {
+	constructor() {
+		super(VXPayHookMessage.HOOK_SIGNUP);
+	}
+}

--- a/test/Fixtures/message/hook-comfort-settings.json
+++ b/test/Fixtures/message/hook-comfort-settings.json
@@ -1,0 +1,6 @@
+{
+	"type": "modalbox-hook",
+	"data": {
+		"hook": "comfortSettingsChanged"
+	}
+}

--- a/test/Fixtures/message/hook-email-not-verified.json
+++ b/test/Fixtures/message/hook-email-not-verified.json
@@ -1,0 +1,6 @@
+{
+	"type": "modalbox-hook",
+	"data": {
+		"hook": "emailNotVerified"
+	}
+}

--- a/test/Fixtures/message/hook-email-verified.json
+++ b/test/Fixtures/message/hook-email-verified.json
@@ -1,0 +1,6 @@
+{
+	"type": "modalbox-hook",
+	"data": {
+		"hook": "emailVerified"
+	}
+}

--- a/test/Fixtures/message/hook-password-changed.json
+++ b/test/Fixtures/message/hook-password-changed.json
@@ -1,0 +1,6 @@
+{
+	"type": "modalbox-hook",
+	"data": {
+		"hook": "passwordChanged"
+	}
+}

--- a/test/Fixtures/message/hook-payment.json
+++ b/test/Fixtures/message/hook-payment.json
@@ -1,0 +1,6 @@
+{
+	"type": "modalbox-hook",
+	"data": {
+		"hook": "payment"
+	}
+}

--- a/test/Fixtures/message/hook-signup.json
+++ b/test/Fixtures/message/hook-signup.json
@@ -1,0 +1,6 @@
+{
+	"type": "modalbox-hook",
+	"data": {
+		"hook": "signup"
+	}
+}

--- a/test/Hooks/VXPayHookMessageFactoryTest.js
+++ b/test/Hooks/VXPayHookMessageFactoryTest.js
@@ -1,10 +1,16 @@
-import {assert}                    from 'chai'
-import {describe, it}              from 'mocha'
-import VXPayHookMessageFactory     from './../../src/VXPay/Message/Hooks/VXPayHookMessageFactory'
-import VXPayHookMessage            from './../../src/VXPay/Message/Hooks/VXPayHookMessage'
-import VXPayLoggedInMessage        from './../../src/VXPay/Message/Hooks/VXPayLoggedInMessage'
-import VXPayFlow                   from './../../src/VXPay/Config/VXPayFlow'
-import VXPayFlowChangedHookMessage from './../../src/VXPay/Message/Hooks/VXPayFlowChangedMessage'
+import {assert}                               from 'chai';
+import {describe, it}                         from 'mocha';
+import VXPayHookMessageFactory                from './../../src/VXPay/Message/Hooks/VXPayHookMessageFactory';
+import VXPayHookMessage                       from './../../src/VXPay/Message/Hooks/VXPayHookMessage';
+import VXPayLoggedInMessage                   from './../../src/VXPay/Message/Hooks/VXPayLoggedInMessage';
+import VXPayFlow                              from './../../src/VXPay/Config/VXPayFlow';
+import VXPayFlowChangedHookMessage            from './../../src/VXPay/Message/Hooks/VXPayFlowChangedMessage';
+import VXPayHookPaymentMessage                from './../../src/VXPay/Message/Hooks/VXPayHookPaymentMessage';
+import VXPayHookSignupMessage                 from './../../src/VXPay/Message/Hooks/VXPayHookSignupMessage';
+import VXPayHookComfortSettingsChangedMessage from './../../src/VXPay/Message/Hooks/VXPayHookComfortSettingsChangedMessage';
+import VXPayHookEmailVerifiedMessage          from './../../src/VXPay/Message/Hooks/VXPayHookEmailVerifiedMessage';
+import VXPayHookEmailNotVerifiedMessage       from './../../src/VXPay/Message/Hooks/VXPayHookEmailNotVerifiedMessage';
+import VXPayHookPasswordChangedMessage        from './../../src/VXPay/Message/Hooks/VXPayHookPasswordChangedMessage';
 
 describe('VXPayHookMessageFactory', () => {
 	describe('#fromData', () => {
@@ -13,20 +19,20 @@ describe('VXPayHookMessageFactory', () => {
 				() => VXPayHookMessageFactory.fromData(),
 				TypeError,
 				'Invalid message format - no hook field'
-			)
+			);
 		});
 		it('Throws errors on invalid data', () => {
 			assert.throws(
 				() => VXPayHookMessageFactory.fromData({foo: 'bar'}),
 				TypeError,
 				'Invalid message format - no hook field'
-			)
+			);
 		});
 		it('Returns an abstract message when unknown hook received', () => {
 			assert.instanceOf(
 				VXPayHookMessageFactory.fromData({hook: 'dummy'}),
 				VXPayHookMessage
-			)
+			);
 		});
 		it('Returns VXPayLoggedInMessage on LOGIN', () => {
 			assert.instanceOf(
@@ -46,5 +52,41 @@ describe('VXPayHookMessageFactory', () => {
 			assert.equal(VXPayFlow.ONE_CLICK, msg.oldFlow);
 			assert.equal(VXPayFlow.LOGIN, msg.newFlow);
 		});
-	})
+		it('Returns VXPayHookPaymentMessage on PAYMENT', () => {
+			assert.instanceOf(
+				VXPayHookMessageFactory.fromData({hook: VXPayHookMessage.HOOK_PAYMENT}),
+				VXPayHookPaymentMessage
+			);
+		});
+		it('Returns VXPayHookSignupMessage on SIGNUP', () => {
+			assert.instanceOf(
+				VXPayHookMessageFactory.fromData({hook: VXPayHookMessage.HOOK_SIGNUP}),
+				VXPayHookSignupMessage
+			);
+		});
+		it('Returns VXPayHookComfortSettingsChangedMessage on COMFORT_SETTINGS_CHANGED', () => {
+			assert.instanceOf(
+				VXPayHookMessageFactory.fromData({hook: VXPayHookMessage.HOOK_COMFORT_SETTINGS_CHANGED}),
+				VXPayHookComfortSettingsChangedMessage
+			);
+		});
+		it('Returns VXPayHookEmailVerifiedMessage on EMAIL_VERIFIED', () => {
+			assert.instanceOf(
+				VXPayHookMessageFactory.fromData({hook: VXPayHookMessage.HOOK_EMAIL_VERIFIED}),
+				VXPayHookEmailVerifiedMessage
+			);
+		});
+		it('Returns VXPayHookEmailNotVerifiedMessage on EMAIL_NOT_VERIFIED', () => {
+			assert.instanceOf(
+				VXPayHookMessageFactory.fromData({hook: VXPayHookMessage.HOOK_EMAIL_NOT_VERIFIED}),
+				VXPayHookEmailNotVerifiedMessage
+			);
+		});
+		it('Returns VXPayHookPasswordChangedMessage on PASSWORD_CHANGED', () => {
+			assert.instanceOf(
+				VXPayHookMessageFactory.fromData({hook: VXPayHookMessage.HOOK_PASSWORD_CHANGED}),
+				VXPayHookPasswordChangedMessage
+			);
+		});
+	});
 });

--- a/test/Hooks/VXPayHooksRouterTest.js
+++ b/test/Hooks/VXPayHooksRouterTest.js
@@ -1,25 +1,31 @@
-import sinon                          from 'sinon'
-import {assert}                       from 'chai'
-import {describe, it}                 from 'mocha'
-import VXPayPaymentHooksConfig        from './../../src/VXPay/Config/VXPayPaymentHooksConfig'
-import VXPayMessageFactory            from './../../src/VXPay/Message/VXPayMessageFactory'
-import VXPayHookRouter                from './../../src/VXPay/Message/Hooks/VXPayHookRouter'
-import VXPayTestFx                    from './../Fixtures/VXPayTestFx'
-import VXPayHasSessionCookieMessage   from './../../src/VXPay/Message/VXPayHasSessionCookieMessage'
-import VXPayIframeReadyMessage        from './../../src/VXPay/Message/VXPayIframeReadyMessage'
-import VXPayContentLoadedMessage      from './../../src/VXPay/Message/VXPayContentLoadedMessage'
-import VXPayViewReadyMessage          from './../../src/VXPay/Message/VXPayViewReadyMessage'
-import VXPayIframeCloseMessage        from './../../src/VXPay/Message/VXPayIframeCloseMessage'
-import VXPaySuccessMessage            from './../../src/VXPay/Message/VXPaySuccessMessage'
-import VXPayHookMessage               from './../../src/VXPay/Message/Hooks/VXPayHookMessage'
-import VXPayTransferTokenMessage      from './../../src/VXPay/Message/VXPayTransferTokenMessage'
-import VXPayAVSStatusMessage          from './../../src/VXPay/Message/Actions/VXPayAVSStatusMessage'
-import VXPayAVSStatus                 from './../../src/VXPay/Model/VXPayAVSStatus'
-import VXPayIsLoggedInResponseMessage from './../../src/VXPay/Message/Actions/VXPayIsLoggedInResponseMessage'
-import VXPayLoggedOutMessage          from './../../src/VXPay/Message/Actions/VXPayLoggedOutMessage'
-import VXPayActiveAbosMessage         from './../../src/VXPay/Message/Actions/VXPayActiveAbosMessage'
-import VXPayBalanceMessage            from './../../src/VXPay/Message/Actions/VXPayBalanceMessage'
-import VXPayFlowChangedHookMessage    from './../../src/VXPay/Message/Hooks/VXPayFlowChangedMessage'
+import sinon                          from 'sinon';
+import {assert}                       from 'chai';
+import {describe, it}                 from 'mocha';
+import VXPayPaymentHooksConfig        from './../../src/VXPay/Config/VXPayPaymentHooksConfig';
+import VXPayMessageFactory            from './../../src/VXPay/Message/VXPayMessageFactory';
+import VXPayHookRouter                from './../../src/VXPay/Message/Hooks/VXPayHookRouter';
+import VXPayTestFx                    from './../Fixtures/VXPayTestFx';
+import VXPayHasSessionCookieMessage   from './../../src/VXPay/Message/VXPayHasSessionCookieMessage';
+import VXPayIframeReadyMessage        from './../../src/VXPay/Message/VXPayIframeReadyMessage';
+import VXPayContentLoadedMessage      from './../../src/VXPay/Message/VXPayContentLoadedMessage';
+import VXPayViewReadyMessage          from './../../src/VXPay/Message/VXPayViewReadyMessage';
+import VXPayIframeCloseMessage        from './../../src/VXPay/Message/VXPayIframeCloseMessage';
+import VXPaySuccessMessage            from './../../src/VXPay/Message/VXPaySuccessMessage';
+import VXPayHookMessage               from './../../src/VXPay/Message/Hooks/VXPayHookMessage';
+import VXPayTransferTokenMessage      from './../../src/VXPay/Message/VXPayTransferTokenMessage';
+import VXPayAVSStatusMessage          from './../../src/VXPay/Message/Actions/VXPayAVSStatusMessage';
+import VXPayAVSStatus                 from './../../src/VXPay/Model/VXPayAVSStatus';
+import VXPayIsLoggedInResponseMessage from './../../src/VXPay/Message/Actions/VXPayIsLoggedInResponseMessage';
+import VXPayLoggedOutMessage                  from './../../src/VXPay/Message/Actions/VXPayLoggedOutMessage';
+import VXPayActiveAbosMessage                 from './../../src/VXPay/Message/Actions/VXPayActiveAbosMessage';
+import VXPayBalanceMessage                    from './../../src/VXPay/Message/Actions/VXPayBalanceMessage';
+import VXPayFlowChangedHookMessage            from './../../src/VXPay/Message/Hooks/VXPayFlowChangedMessage';
+import VXPayHookPaymentMessage                from '../../src/VXPay/Message/Hooks/VXPayHookPaymentMessage';
+import VXPayHookSignupMessage                 from '../../src/VXPay/Message/Hooks/VXPayHookSignupMessage';
+import VXPayHookComfortSettingsChangedMessage from '../../src/VXPay/Message/Hooks/VXPayHookComfortSettingsChangedMessage';
+import VXPayHookEmailVerifiedMessage          from '../../src/VXPay/Message/Hooks/VXPayHookEmailVerifiedMessage';
+import VXPayHookEmailNotVerifiedMessage       from '../../src/VXPay/Message/Hooks/VXPayHookEmailNotVerifiedMessage';
+import VXPayHookPasswordChangedMessage        from '../../src/VXPay/Message/Hooks/VXPayHookPasswordChangedMessage';
 
 describe('VXPayHookRouter', () => {
 	it('Will parse event data', () => {
@@ -51,7 +57,7 @@ describe('VXPayHookRouter', () => {
 
 		trigger.restore();
 
-		sinon.assert.calledWith(trigger, VXPayPaymentHooksConfig.ON_ANY, [msgInstance])
+		sinon.assert.calledWith(trigger, VXPayPaymentHooksConfig.ON_ANY, [msgInstance]);
 	});
 	it('Will trigger `onAny` & `onIframeReady` on ready iframe', () => {
 		const config      = new VXPayPaymentHooksConfig(),
@@ -217,5 +223,71 @@ describe('VXPayHookRouter', () => {
 
 		sinon.assert.calledWith(trigger, VXPayPaymentHooksConfig.ON_ANY, [msgInstance]);
 		sinon.assert.calledWith(trigger, VXPayPaymentHooksConfig.ON_FLOW_CHANGE, [msgInstance]);
+	});
+	it('Will trigger `onAny` && `onPayment` on corresponding messages', () => {
+		const config      = new VXPayPaymentHooksConfig(),
+		      eventString = VXPayTestFx.getMessage('hook-payment'),
+		      msgInstance = new VXPayHookPaymentMessage(),
+		      trigger     = sinon.spy(config, 'trigger');
+
+		VXPayHookRouter(config, {data: eventString});
+
+		sinon.assert.calledWith(trigger, VXPayPaymentHooksConfig.ON_ANY, [msgInstance]);
+		sinon.assert.calledWith(trigger, VXPayPaymentHooksConfig.ON_PAYMENT, [msgInstance]);
+	});
+	it('Will trigger `onAny` && `onSignup` on corresponding messages', () => {
+		const config      = new VXPayPaymentHooksConfig(),
+		      eventString = VXPayTestFx.getMessage('hook-signup'),
+		      msgInstance = new VXPayHookSignupMessage(),
+		      trigger     = sinon.spy(config, 'trigger');
+
+		VXPayHookRouter(config, {data: eventString});
+
+		sinon.assert.calledWith(trigger, VXPayPaymentHooksConfig.ON_ANY, [msgInstance]);
+		sinon.assert.calledWith(trigger, VXPayPaymentHooksConfig.ON_SIGNUP, [msgInstance]);
+	});
+	it('Will trigger `onAny` && `onComfortSettingsChanged` on corresponding messages', () => {
+		const config      = new VXPayPaymentHooksConfig(),
+		      eventString = VXPayTestFx.getMessage('hook-comfort-settings'),
+		      msgInstance = new VXPayHookComfortSettingsChangedMessage(),
+		      trigger     = sinon.spy(config, 'trigger');
+
+		VXPayHookRouter(config, {data: eventString});
+
+		sinon.assert.calledWith(trigger, VXPayPaymentHooksConfig.ON_ANY, [msgInstance]);
+		sinon.assert.calledWith(trigger, VXPayPaymentHooksConfig.ON_COMFORT_SETTINGS_CHANGE, [msgInstance]);
+	});
+	it('Will trigger `onAny` && `onEmailVerified` on corresponding messages', () => {
+		const config      = new VXPayPaymentHooksConfig(),
+		      eventString = VXPayTestFx.getMessage('hook-email-verified'),
+		      msgInstance = new VXPayHookEmailVerifiedMessage(),
+		      trigger     = sinon.spy(config, 'trigger');
+
+		VXPayHookRouter(config, {data: eventString});
+
+		sinon.assert.calledWith(trigger, VXPayPaymentHooksConfig.ON_ANY, [msgInstance]);
+		sinon.assert.calledWith(trigger, VXPayPaymentHooksConfig.ON_EMAIL_VERIFIED, [msgInstance]);
+	});
+	it('Will trigger `onAny` && `onEmailNotVerified` on corresponding messages', () => {
+		const config      = new VXPayPaymentHooksConfig(),
+		      eventString = VXPayTestFx.getMessage('hook-email-not-verified'),
+		      msgInstance = new VXPayHookEmailNotVerifiedMessage(),
+		      trigger     = sinon.spy(config, 'trigger');
+
+		VXPayHookRouter(config, {data: eventString});
+
+		sinon.assert.calledWith(trigger, VXPayPaymentHooksConfig.ON_ANY, [msgInstance]);
+		sinon.assert.calledWith(trigger, VXPayPaymentHooksConfig.ON_EMAIL_NOT_VERIFIED, [msgInstance]);
+	});
+	it('Will trigger `onAny` && `onPasswordChanged` on corresponding messages', () => {
+		const config      = new VXPayPaymentHooksConfig(),
+		      eventString = VXPayTestFx.getMessage('hook-password-changed'),
+		      msgInstance = new VXPayHookPasswordChangedMessage(),
+		      trigger     = sinon.spy(config, 'trigger');
+
+		VXPayHookRouter(config, {data: eventString});
+
+		sinon.assert.calledWith(trigger, VXPayPaymentHooksConfig.ON_ANY, [msgInstance]);
+		sinon.assert.calledWith(trigger, VXPayPaymentHooksConfig.ON_PASSWORD_CHANGED, [msgInstance]);
 	});
 });


### PR DESCRIPTION
#### The problem:

- Not all hooks available in API are available in the library, resulted in unknown hooks triggered and not processed properly

![dummy-hook](https://user-images.githubusercontent.com/1280013/47444316-e4f7c000-d7be-11e8-87db-8cc3b04981ee.jpg)

#### The solution:

- Added `VXPayPaymentHooksConfig.ON_PAYMENT`
- Added `VXPayPaymentHooksConfig.ON_SIGNUP`
- Added `VXPayPaymentHooksConfig.ON_COMFORT_SETTINGS_CHANGE`
- Added `VXPayPaymentHooksConfig.ON_EMAIL_VERIFIED`
- Added `VXPayPaymentHooksConfig.ON_EMAIL_NOT_VERIFIED`
- Added `VXPayPaymentHooksConfig.ON_PASSWORD_CHANGED`

Documentation update to follow.
