### PR TITLE
Fix enable tab

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vxpay-js",
-  "version": "2.3.2",
+  "version": "2.4.0",
   "description": "Javascript library to initialize and handle VXPay iframe",
   "main": "dist/vxpay.min.js",
   "author": "Igor Timoshenkov",

--- a/src/VXPay.js
+++ b/src/VXPay.js
@@ -1,47 +1,47 @@
-import VXPayConfig                         from './VXPay/VXPayConfig'
-import VXPayLogger                         from './VXPay/VXPayLogger'
-import VXPayHelperFrame                    from './VXPay/Dom/Frame/VXPayHelperFrame'
-import VXPayPaymentFrame                   from './VXPay/Dom/Frame/VXPayPaymentFrame'
-import VXPayPaymentTab                     from './VXPay/Dom/Frame/VXPayPaymentTab'
-import VXPayInitPaymentMiddleware          from './VXPay/Middleware/Frames/VXPayInitPaymentMiddleware'
-import VXPayInitHelperMiddleware           from './VXPay/Middleware/Frames/VXPayInitHelperMiddleware'
-import VXPayListenOrCallLoggedInMiddleware from './VXPay/Middleware/Actions/VXPayListenOrCallLoggedInMiddleware'
-import VXPayOnAVSStatusListenMiddleware    from './VXPay/Middleware/Actions/VXPayOnAVSStatusListenMiddleware'
-import VXPayAVSStatusTriggerMiddleware     from './VXPay/Middleware/Actions/VXPayAVSStatusTriggerMiddleware'
-import VXPayListenForBalanceMiddleware     from './VXPay/Middleware/Actions/VXPayListenForBalanceMiddleware'
-import VXPayBalanceTriggerMiddleware       from './VXPay/Middleware/Actions/VXPayBalanceTriggerMiddleware'
-import VXPayListenForActiveAbosMiddleware  from './VXPay/Middleware/Actions/VXPayListenForActiveAbosMiddleware'
-import VXPayActiveAbosTriggerMiddleware    from './VXPay/Middleware/Actions/VXPayActiveAbosTriggerMiddleware'
-import VXPayListenForLogoutMiddleware      from './VXPay/Middleware/Actions/VXPayListenForLogoutMiddleware'
-import VXPayLogoutTriggerMiddleware        from './VXPay/Middleware/Actions/VXPayLogoutTriggerMiddleware'
-import VXPayState                          from './VXPay/Model/VXPayState'
-import VXPayWhenTokenTransferred           from './VXPay/Middleware/Condition/VXPayWhenTokenTransferred'
-import VXPayOpenLoginCommand               from './VXPay/Middleware/Command/VXPayOpenLoginCommand'
-import VXPayOpenSignUpCommand              from './VXPay/Middleware/Command/VXPayOpenSignUpCommand'
-import VXPayOpenVoiceCallCommand           from './VXPay/Middleware/Command/VXPayOpenVoiceCallCommand'
-import VXPayOpenPaymentCommand             from './VXPay/Middleware/Command/VXPayOpenPaymentCommand'
-import VXPayOpenSettingsCommand            from './VXPay/Middleware/Command/VXPayOpenSettingsCommand'
-import VXPayOpenAboCommand                 from './VXPay/Middleware/Command/VXPayOpenAboCommand'
-import VXPayResetPasswordCommand           from './VXPay/Middleware/Command/VXPayResetPasswordCommand'
-import VXPayLostPasswordCommand            from './VXPay/Middleware/Command/VXPayLostPasswordCommand'
-import VXPayOpenLimitedPaymentCommand      from './VXPay/Middleware/Command/VXPayOpenLimitedPaymentCommand'
-import VXPayOpenVipAboTrialCommand         from './VXPay/Middleware/Command/VXPayOpenVipAboTrialCommand'
-import VXPayOpenPremiumAboCommand          from './VXPay/Middleware/Command/VXPayOpenPremiumAboCommand'
-import VXPayOpenAVSCommand                 from './VXPay/Middleware/Command/VXPayOpenAVSCommand'
-import VXPayOpenPromoCodeCommand           from './VXPay/Middleware/Command/VXPayOpenPromoCodeCommand'
-import VXPayOpenOneClickCommand            from './VXPay/Middleware/Command/VXPayOpenOneClickCommand'
-import VXPayOpenAutoRechargeCommand        from './VXPay/Middleware/Command/VXPayOpenAutoRechargeCommand'
-import VXPayOpenOpenBalanceCommand         from './VXPay/Middleware/Command/VXPayOpenOpenBalanceCommand'
-import VXPayTriggerShowForTab              from './VXPay/Middleware/Frames/VXPayTriggerShowForTab'
+import VXPayConfig                         from './VXPay/VXPayConfig';
+import VXPayLogger                         from './VXPay/VXPayLogger';
+import VXPayHelperFrame                    from './VXPay/Dom/Frame/VXPayHelperFrame';
+import VXPayPaymentFrame                   from './VXPay/Dom/Frame/VXPayPaymentFrame';
+import VXPayPaymentTab                     from './VXPay/Dom/Frame/VXPayPaymentTab';
+import VXPayInitPaymentMiddleware          from './VXPay/Middleware/Frames/VXPayInitPaymentMiddleware';
+import VXPayInitHelperMiddleware           from './VXPay/Middleware/Frames/VXPayInitHelperMiddleware';
+import VXPayListenOrCallLoggedInMiddleware from './VXPay/Middleware/Actions/VXPayListenOrCallLoggedInMiddleware';
+import VXPayOnAVSStatusListenMiddleware    from './VXPay/Middleware/Actions/VXPayOnAVSStatusListenMiddleware';
+import VXPayAVSStatusTriggerMiddleware     from './VXPay/Middleware/Actions/VXPayAVSStatusTriggerMiddleware';
+import VXPayListenForBalanceMiddleware     from './VXPay/Middleware/Actions/VXPayListenForBalanceMiddleware';
+import VXPayBalanceTriggerMiddleware       from './VXPay/Middleware/Actions/VXPayBalanceTriggerMiddleware';
+import VXPayListenForActiveAbosMiddleware  from './VXPay/Middleware/Actions/VXPayListenForActiveAbosMiddleware';
+import VXPayActiveAbosTriggerMiddleware    from './VXPay/Middleware/Actions/VXPayActiveAbosTriggerMiddleware';
+import VXPayListenForLogoutMiddleware      from './VXPay/Middleware/Actions/VXPayListenForLogoutMiddleware';
+import VXPayLogoutTriggerMiddleware        from './VXPay/Middleware/Actions/VXPayLogoutTriggerMiddleware';
+import VXPayState                          from './VXPay/Model/VXPayState';
+import VXPayWhenTokenTransferred           from './VXPay/Middleware/Condition/VXPayWhenTokenTransferred';
+import VXPayOpenLoginCommand               from './VXPay/Middleware/Command/VXPayOpenLoginCommand';
+import VXPayOpenSignUpCommand              from './VXPay/Middleware/Command/VXPayOpenSignUpCommand';
+import VXPayOpenVoiceCallCommand           from './VXPay/Middleware/Command/VXPayOpenVoiceCallCommand';
+import VXPayOpenPaymentCommand             from './VXPay/Middleware/Command/VXPayOpenPaymentCommand';
+import VXPayOpenSettingsCommand            from './VXPay/Middleware/Command/VXPayOpenSettingsCommand';
+import VXPayOpenAboCommand                 from './VXPay/Middleware/Command/VXPayOpenAboCommand';
+import VXPayResetPasswordCommand           from './VXPay/Middleware/Command/VXPayResetPasswordCommand';
+import VXPayLostPasswordCommand            from './VXPay/Middleware/Command/VXPayLostPasswordCommand';
+import VXPayOpenLimitedPaymentCommand      from './VXPay/Middleware/Command/VXPayOpenLimitedPaymentCommand';
+import VXPayOpenVipAboTrialCommand         from './VXPay/Middleware/Command/VXPayOpenVipAboTrialCommand';
+import VXPayOpenPremiumAboCommand          from './VXPay/Middleware/Command/VXPayOpenPremiumAboCommand';
+import VXPayOpenAVSCommand                 from './VXPay/Middleware/Command/VXPayOpenAVSCommand';
+import VXPayOpenPromoCodeCommand           from './VXPay/Middleware/Command/VXPayOpenPromoCodeCommand';
+import VXPayOpenOneClickCommand            from './VXPay/Middleware/Command/VXPayOpenOneClickCommand';
+import VXPayOpenAutoRechargeCommand        from './VXPay/Middleware/Command/VXPayOpenAutoRechargeCommand';
+import VXPayOpenOpenBalanceCommand         from './VXPay/Middleware/Command/VXPayOpenOpenBalanceCommand';
+import VXPayTriggerShowForTab              from './VXPay/Middleware/Frames/VXPayTriggerShowForTab';
 
 export default class VXPay {
 	/**
 	 * @param {VXPayConfig} config
 	 */
 	constructor(config) {
-		this.config      = config;
-		this.logger      = new VXPayLogger(this.config.logging, this.config.window);
-		this._state      = new VXPayState();
+		this.config = config;
+		this.logger = new VXPayLogger(this.config.logging, this.config.window);
+		this._state = new VXPayState();
 		this.logger.log('VXPay::constructor - ' + JSON.stringify(this.config.getOptions()));
 	}
 
@@ -54,10 +54,9 @@ export default class VXPay {
 
 	/**
 	 * @return {Promise<VXPay>}
-	 * @private
 	 */
-	_initHelperFrame() {
-		return new Promise(resolve => VXPayInitHelperMiddleware(this, resolve))
+	initHelperFrame() {
+		return new Promise(resolve => VXPayInitHelperMiddleware(this, resolve));
 	}
 
 	/**
@@ -67,7 +66,7 @@ export default class VXPay {
 	 */
 	_initPaymentFrame(triggerLoad = true) {
 		this.logger.log('VXPay::_initPaymentFrame', triggerLoad);
-		return new Promise(resolve => VXPayInitPaymentMiddleware(this, resolve, triggerLoad))
+		return new Promise(resolve => VXPayInitPaymentMiddleware(this, resolve, triggerLoad));
 	}
 
 	/**
@@ -83,7 +82,7 @@ export default class VXPay {
 				.then(vxpay => VXPayOpenLoginCommand(vxpay, flowOptions))
 				.then(VXPayTriggerShowForTab)
 				.then(resolve)
-				.catch(reject)
+				.catch(reject);
 		});
 	}
 
@@ -98,7 +97,7 @@ export default class VXPay {
 				.then(vxpay => VXPayOpenSignUpCommand(vxpay, flowOptions))
 				.then(VXPayTriggerShowForTab)
 				.then(resolve)
-				.catch(reject)
+				.catch(reject);
 		});
 	}
 
@@ -112,8 +111,8 @@ export default class VXPay {
 				.then(VXPayOpenVoiceCallCommand.run)
 				.then(VXPayTriggerShowForTab)
 				.then(resolve)
-				.catch(reject)
-		})
+				.catch(reject);
+		});
 	}
 
 	/**
@@ -121,9 +120,9 @@ export default class VXPay {
 	 * @return {Promise<VXPay>}
 	 */
 	openSignUpOrLogin(flowOptions = {}) {
-		return this._initHelperFrame()
+		return this.initHelperFrame()
 			.then(vxpay => vxpay.helperFrame.getLoginCookie())
-			.then(msg => msg.hasCookie ? this.openLogin(flowOptions) : this.openSignUp(flowOptions))
+			.then(msg => msg.hasCookie ? this.openLogin(flowOptions) : this.openSignUp(flowOptions));
 	}
 
 	/**
@@ -137,8 +136,8 @@ export default class VXPay {
 				.then(vxpay => VXPayOpenPaymentCommand.run(vxpay, flowOptions))
 				.then(VXPayTriggerShowForTab)
 				.then(resolve)
-				.catch(reject)
-		})
+				.catch(reject);
+		});
 	}
 
 	/**
@@ -152,8 +151,8 @@ export default class VXPay {
 				.then(vxpay => VXPayOpenAboCommand(vxpay, flowOptions))
 				.then(VXPayTriggerShowForTab)
 				.then(resolve)
-				.catch(reject)
-		})
+				.catch(reject);
+		});
 	}
 
 	/**
@@ -166,8 +165,8 @@ export default class VXPay {
 				.then(VXPayOpenSettingsCommand.run)
 				.then(VXPayTriggerShowForTab)
 				.then(resolve)
-				.catch(reject)
-		})
+				.catch(reject);
+		});
 	}
 
 	/**
@@ -181,8 +180,8 @@ export default class VXPay {
 				.then(vxpay => VXPayResetPasswordCommand.run(vxpay, flowOptions))
 				.then(VXPayTriggerShowForTab)
 				.then(resolve)
-				.catch(reject)
-		})
+				.catch(reject);
+		});
 	}
 
 	/**
@@ -196,8 +195,8 @@ export default class VXPay {
 				.then(vxpay => VXPayLostPasswordCommand.run(vxpay, flowOptions))
 				.then(VXPayTriggerShowForTab)
 				.then(resolve)
-				.catch(reject)
-		})
+				.catch(reject);
+		});
 	}
 
 	/**
@@ -210,8 +209,8 @@ export default class VXPay {
 				.then(VXPayOpenLimitedPaymentCommand.run)
 				.then(VXPayTriggerShowForTab)
 				.then(resolve)
-				.catch(reject)
-		})
+				.catch(reject);
+		});
 	}
 
 	/**
@@ -225,8 +224,8 @@ export default class VXPay {
 				.then(vxpay => VXPayOpenVipAboTrialCommand(vxpay, flowOptions))
 				.then(VXPayTriggerShowForTab)
 				.then(resolve)
-				.catch(reject)
-		})
+				.catch(reject);
+		});
 	}
 
 	/**
@@ -240,8 +239,8 @@ export default class VXPay {
 				.then(vxpay => VXPayOpenPremiumAboCommand(vxpay, flowOptions))
 				.then(VXPayTriggerShowForTab)
 				.then(resolve)
-				.catch(reject)
-		})
+				.catch(reject);
+		});
 	}
 
 	/**
@@ -255,8 +254,8 @@ export default class VXPay {
 				.then(vxpay => VXPayOpenAVSCommand(vxpay, flowOptions))
 				.then(VXPayTriggerShowForTab)
 				.then(resolve)
-				.catch(reject)
-		})
+				.catch(reject);
+		});
 	}
 
 	/**
@@ -270,8 +269,8 @@ export default class VXPay {
 				.then(vxpay => VXPayOpenPromoCodeCommand(vxpay, flowOptions))
 				.then(VXPayTriggerShowForTab)
 				.then(resolve)
-				.catch(reject)
-		})
+				.catch(reject);
+		});
 	}
 
 	/**
@@ -285,8 +284,8 @@ export default class VXPay {
 				.then(vxpay => VXPayOpenPromoCodeCommand(vxpay, flowOptions))
 				.then(VXPayTriggerShowForTab)
 				.then(resolve)
-				.catch(reject)
-		})
+				.catch(reject);
+		});
 	}
 
 	/**
@@ -300,8 +299,8 @@ export default class VXPay {
 				.then(vxpay => VXPayOpenOneClickCommand.run(vxpay, flowOptions))
 				.then(VXPayTriggerShowForTab)
 				.then(resolve)
-				.catch(reject)
-		})
+				.catch(reject);
+		});
 	}
 
 	/**
@@ -315,8 +314,8 @@ export default class VXPay {
 				.then(vxpay => VXPayOpenAutoRechargeCommand.run(vxpay, flowOptions))
 				.then(VXPayTriggerShowForTab)
 				.then(resolve)
-				.catch(reject)
-		})
+				.catch(reject);
+		});
 	}
 
 	/**
@@ -330,8 +329,8 @@ export default class VXPay {
 				.then(vxpay => VXPayOpenOpenBalanceCommand(vxpay, flowOptions))
 				.then(VXPayTriggerShowForTab)
 				.then(resolve)
-				.catch(reject)
-		})
+				.catch(reject);
+		});
 	}
 
 	/**
@@ -339,9 +338,9 @@ export default class VXPay {
 	 */
 	isLoggedIn() {
 		return new Promise((resolve, reject) => {
-			this._initPaymentFrame()
+			this._initPaymentFrame(!this.config.enableTab)
 				.then(vxpay => (new VXPayListenOrCallLoggedInMiddleware(vxpay, resolve, reject)).run())
-				.catch(reject)
+				.catch(reject);
 		});
 	}
 
@@ -353,8 +352,8 @@ export default class VXPay {
 			return this._initPaymentFrame()
 				.then(vxpay => VXPayOnAVSStatusListenMiddleware(vxpay, resolve, reject))
 				.then(VXPayAVSStatusTriggerMiddleware)
-				.catch(reject)
-		})
+				.catch(reject);
+		});
 	}
 
 	/**
@@ -365,7 +364,7 @@ export default class VXPay {
 			this._initPaymentFrame()
 				.then(vxpay => VXPayListenForBalanceMiddleware(vxpay, resolve, reject))
 				.then(VXPayBalanceTriggerMiddleware)
-				.catch(reject)
+				.catch(reject);
 		});
 	}
 
@@ -377,8 +376,8 @@ export default class VXPay {
 			this._initPaymentFrame()
 				.then(vxpay => VXPayListenForActiveAbosMiddleware(vxpay, resolve, reject))
 				.then(VXPayActiveAbosTriggerMiddleware)
-				.catch(reject)
-		})
+				.catch(reject);
+		});
 	}
 
 	/**
@@ -389,8 +388,8 @@ export default class VXPay {
 			this._initPaymentFrame()
 				.then(vxpay => VXPayListenForLogoutMiddleware(vxpay, resolve, reject))
 				.then(VXPayLogoutTriggerMiddleware)
-				.catch(reject)
-		})
+				.catch(reject);
+		});
 	}
 
 	/**
@@ -473,7 +472,7 @@ export default class VXPay {
 		return new Promise((resolve, reject) => {
 			this._initPaymentFrame()
 				.then(vxpay => resolve(vxpay._paymentFrame))
-				.catch(reject)
+				.catch(reject);
 		});
 	}
 

--- a/src/VXPay/Config/VXPayHooksConfig.js
+++ b/src/VXPay/Config/VXPayHooksConfig.js
@@ -38,7 +38,7 @@ class VXPayHooksConfig {
 	 * @param {String|undefined} sourceTab
 	 * @return {boolean}
 	 */
-	trigger(hook, callbackArguments = [], sourceTab = undefined) {
+	trigger(hook, callbackArguments = [], sourceTab = undefined) { /* eslint-disable-line no-unused-vars  */
 		const name = '_' + hook;
 
 		if (!this.hasOwnProperty(name)) {

--- a/src/VXPay/Config/VXPayHooksConfig.js
+++ b/src/VXPay/Config/VXPayHooksConfig.js
@@ -35,9 +35,10 @@ class VXPayHooksConfig {
 	/**
 	 * @param {String} hook
 	 * @param {Array} callbackArguments
+	 * @param {String|undefined} sourceTab
 	 * @return {boolean}
 	 */
-	trigger(hook, callbackArguments = []) {
+	trigger(hook, callbackArguments = [], sourceTab = undefined) {
 		const name = '_' + hook;
 
 		if (!this.hasOwnProperty(name)) {

--- a/src/VXPay/Dom/Frame/VXPayHelperFrame.js
+++ b/src/VXPay/Dom/Frame/VXPayHelperFrame.js
@@ -1,9 +1,9 @@
-import VXPayIframe                  from './../VXPayIframe'
-import VXPayHasSessionCookieMessage from './../../Message/VXPayHasSessionCookieMessage'
-import VXPayMessageFactory          from './../../Message/VXPayMessageFactory'
-import VXPayEventListener           from './../../Event/VXPayEventListener'
-import VXPayHelperHooksConfig       from './../../Config/VXPayHelperHooksConfig'
-import VXPayHooksConfig             from './../../Config/VXPayHooksConfig'
+import VXPayIframe                  from './../VXPayIframe';
+import VXPayHasSessionCookieMessage from './../../Message/VXPayHasSessionCookieMessage';
+import VXPayMessageFactory          from './../../Message/VXPayMessageFactory';
+import VXPayEventListener           from './../../Event/VXPayEventListener';
+import VXPayHelperHooksConfig       from './../../Config/VXPayHelperHooksConfig';
+import VXPayHooksConfig             from './../../Config/VXPayHooksConfig';
 
 class VXPayHelperFrame extends VXPayIframe {
 	/**
@@ -15,9 +15,9 @@ class VXPayHelperFrame extends VXPayIframe {
 	constructor(document, url, id = VXPayHelperFrame.NAME, style = VXPayHelperFrame.STYLE_DEFAULT) {
 		// init the frame
 		super(document, url, id, style);
-		this._cookieMsg = null;
+		this._cookieMsg  = null;
 		this._frame.name = 'vxpay-helper';
-		this._hooks = new VXPayHelperHooksConfig();
+		this._hooks      = new VXPayHelperHooksConfig();
 	}
 
 	/**
@@ -40,7 +40,7 @@ class VXPayHelperFrame extends VXPayIframe {
 		}
 
 		// trigger hook
-		this._hooks.trigger(VXPayHooksConfig.ON_ANY, [this._cookieMsg]);
+		this._hooks.trigger(VXPayHooksConfig.ON_ANY, [this._cookieMsg], this._frame.id + '<VXPayHelperFrame>');
 
 		// otherwise - not logged in
 		resolve(this._cookieMsg);
@@ -59,13 +59,13 @@ class VXPayHelperFrame extends VXPayIframe {
 				VXPayIframe.EVENT_MESSAGE,
 				this._frame.ownerDocument.defaultView,
 				this._cookieMessageHandler.bind(this, resolve, reject)
-			)
-		})
+			);
+		});
 	}
 
 	_markLoaded() {
 		super._markLoaded();
-		this._hooks.trigger(VXPayHelperHooksConfig.ON_LOAD);
+		this._hooks.trigger(VXPayHelperHooksConfig.ON_LOAD, [], this._frame.id + '<VXPayHelperFrame>');
 	}
 
 	/**
@@ -74,7 +74,7 @@ class VXPayHelperFrame extends VXPayIframe {
 	 * @param {String} origin
 	 */
 	postMessage(message, origin = '*') {
-		this._hooks.trigger(VXPayHelperHooksConfig.ON_BEFORE_SEND, [message]);
+		this._hooks.trigger(VXPayHelperHooksConfig.ON_BEFORE_SEND, [message], this._frame.id + '<VXPayHelperFrame>');
 		super.postMessage(message, origin);
 	}
 
@@ -102,4 +102,4 @@ VXPayHelperFrame.STYLE_DEFAULT = {display: 'none'};
 
 VXPayHelperFrame.NAME = 'vx-helper-frame-payment';
 
-export default VXPayHelperFrame
+export default VXPayHelperFrame;

--- a/src/VXPay/Dom/Frame/VXPayPaymentFrame.js
+++ b/src/VXPay/Dom/Frame/VXPayPaymentFrame.js
@@ -97,7 +97,7 @@ class VXPayPaymentFrame extends VXPayIframe {
 		VXPayEventListener.addEvent(
 			VXPayIframe.EVENT_MESSAGE,
 			this._frame.ownerDocument.defaultView,
-			(event) => VXPayHookRouter(this._hooks, event)
+			(event) => VXPayHookRouter(this._hooks, event, this._frame.id + '<VXPayPaymentFrame>')
 		);
 
 		VXPayEventListener.addEvent(
@@ -114,7 +114,7 @@ class VXPayPaymentFrame extends VXPayIframe {
 		VXPayEventListener.removeEvent(
 			VXPayIframe.EVENT_MESSAGE,
 			this._frame.ownerDocument.defaultView,
-			(event) => VXPayHookRouter(this._hooks, event)
+			(event) => VXPayHookRouter(this._hooks, event, this._frame.id + '<VXPayPaymentFrame>')
 		);
 
 		VXPayEventListener.removeEvent(
@@ -130,7 +130,7 @@ class VXPayPaymentFrame extends VXPayIframe {
 	 */
 	_markLoaded() {
 		super._markLoaded();
-		return this._hooks.trigger(VXPayPaymentHooksConfig.ON_LOAD);
+		return this._hooks.trigger(VXPayPaymentHooksConfig.ON_LOAD, this._frame.id + '<VXPayPaymentFrame>');
 	}
 
 	/**
@@ -140,7 +140,7 @@ class VXPayPaymentFrame extends VXPayIframe {
 	 * @return {VXPayPaymentFrame}
 	 */
 	postMessage(message, origin = '*') {
-		this._hooks.trigger(VXPayPaymentHooksConfig.ON_BEFORE_SEND, [message]);
+		this._hooks.trigger(VXPayPaymentHooksConfig.ON_BEFORE_SEND, [message], this._frame.id + '<VXPayPaymentFrame>');
 
 		if (this._frame.contentWindow !== null) {
 			this._frame.contentWindow.postMessage(message.toString(), origin);

--- a/src/VXPay/Message/Hooks/VXPayHookRouter.js
+++ b/src/VXPay/Message/Hooks/VXPayHookRouter.js
@@ -7,11 +7,12 @@ import VXPayIframe             from './../../Dom/VXPayIframe'
 /**
  * @param {VXPayPaymentHooksConfig} hooks
  * @param {MessageEvent|Object} event
+ * @param {String|undefined} sourceTab
  * @return {boolean}
  * @throws {TypeError}
  * @constructor
  */
-const VXPayHookRouter = (hooks, event) => {
+const VXPayHookRouter = (hooks, event, sourceTab = undefined) => {
 	// origin check
 	if (event.origin && VXPayIframe.ORIGIN_VX.indexOf(event.origin) === -1) {
 		return false;
@@ -21,67 +22,67 @@ const VXPayHookRouter = (hooks, event) => {
 	const message = VXPayMessageFactory.fromJson(event.data);
 
 	// route any
-	hooks.trigger(VXPayPaymentHooksConfig.ON_ANY, [message]);
+	hooks.trigger(VXPayPaymentHooksConfig.ON_ANY, [message], sourceTab);
 
 	switch (message.type) {
 		case VXPayMessage.TYPE_TRANSFER_TOKEN:
-			return hooks.trigger(VXPayPaymentHooksConfig.ON_TRANSFER_TOKEN, [message]);
+			return hooks.trigger(VXPayPaymentHooksConfig.ON_TRANSFER_TOKEN, [message], sourceTab);
 
 		case VXPayMessage.TYPE_AVS_STATUS:
-			return hooks.trigger(VXPayPaymentHooksConfig.ON_AVS_STATUS, [message]);
+			return hooks.trigger(VXPayPaymentHooksConfig.ON_AVS_STATUS, [message], sourceTab);
 
 		case VXPayMessage.TYPE_BALANCE:
-			return hooks.trigger(VXPayPaymentHooksConfig.ON_BALANCE, [message]);
+			return hooks.trigger(VXPayPaymentHooksConfig.ON_BALANCE, [message], sourceTab);
 
 		case VXPayMessage.TYPE_ACTIVE_ABOS:
-			return hooks.trigger(VXPayPaymentHooksConfig.ON_ACTIVE_ABOS, [message]);
+			return hooks.trigger(VXPayPaymentHooksConfig.ON_ACTIVE_ABOS, [message], sourceTab);
 
 		case VXPayMessage.TYPE_IFRAME_READY:
-			return hooks.trigger(VXPayPaymentHooksConfig.ON_IFRAME_READY, [message]);
+			return hooks.trigger(VXPayPaymentHooksConfig.ON_IFRAME_READY, [message], sourceTab);
 
 		case VXPayMessage.TYPE_CONTENT_LOADED:
-			return hooks.trigger(VXPayPaymentHooksConfig.ON_CONTENT_LOADED, [message]);
+			return hooks.trigger(VXPayPaymentHooksConfig.ON_CONTENT_LOADED, [message], sourceTab);
 
 		case VXPayMessage.TYPE_VIEW_READY:
-			return hooks.trigger(VXPayPaymentHooksConfig.ON_VIEW_READY, [message]);
+			return hooks.trigger(VXPayPaymentHooksConfig.ON_VIEW_READY, [message], sourceTab);
 
 		case VXPayMessage.TYPE_IFRAME_CLOSE:
-			return hooks.trigger(VXPayPaymentHooksConfig.ON_CLOSE, [message]);
+			return hooks.trigger(VXPayPaymentHooksConfig.ON_CLOSE, [message], sourceTab);
 
 		case VXPayMessage.TYPE_SUCCESS:
-			return hooks.trigger(VXPayPaymentHooksConfig.ON_SUCCESS, [message]);
+			return hooks.trigger(VXPayPaymentHooksConfig.ON_SUCCESS, [message], sourceTab);
 
 		case VXPayMessage.TYPE_IS_LOGGED_IN:
-			return hooks.trigger(VXPayPaymentHooksConfig.ON_IS_LOGGED_IN, [message]);
+			return hooks.trigger(VXPayPaymentHooksConfig.ON_IS_LOGGED_IN, [message], sourceTab);
 
 		case VXPayMessage.TYPE_LOGGED_OUT:
-			return hooks.trigger(VXPayPaymentHooksConfig.ON_LOGOUT, [message]);
+			return hooks.trigger(VXPayPaymentHooksConfig.ON_LOGOUT, [message], sourceTab);
 
 		case VXPayMessage.TYPE_HOOK:
 			switch (message.hook) {
 				case VXPayHookMessage.HOOK_LOGIN:
-					return hooks.trigger(VXPayPaymentHooksConfig.ON_LOGIN, [message]);
+					return hooks.trigger(VXPayPaymentHooksConfig.ON_LOGIN, [message], sourceTab);
 
 				case VXPayHookMessage.HOOK_FLOW_CHANGED:
-					return hooks.trigger(VXPayPaymentHooksConfig.ON_FLOW_CHANGE, [message]);
+					return hooks.trigger(VXPayPaymentHooksConfig.ON_FLOW_CHANGE, [message], sourceTab);
 
 				case VXPayHookMessage.HOOK_PAYMENT:
-					return hooks.trigger(VXPayPaymentHooksConfig.ON_PAYMENT, [message]);
+					return hooks.trigger(VXPayPaymentHooksConfig.ON_PAYMENT, [message], sourceTab);
 
 				case VXPayHookMessage.HOOK_SIGNUP:
-					return hooks.trigger(VXPayPaymentHooksConfig.ON_SIGNUP, [message]);
+					return hooks.trigger(VXPayPaymentHooksConfig.ON_SIGNUP, [message], sourceTab);
 
 				case VXPayHookMessage.HOOK_COMFORT_SETTINGS_CHANGED:
-					return hooks.trigger(VXPayPaymentHooksConfig.ON_COMFORT_SETTINGS_CHANGE, [message]);
+					return hooks.trigger(VXPayPaymentHooksConfig.ON_COMFORT_SETTINGS_CHANGE, [message], sourceTab);
 
 				case VXPayHookMessage.HOOK_EMAIL_VERIFIED:
-					return hooks.trigger(VXPayPaymentHooksConfig.ON_EMAIL_VERIFIED, [message]);
+					return hooks.trigger(VXPayPaymentHooksConfig.ON_EMAIL_VERIFIED, [message], sourceTab);
 
 				case VXPayHookMessage.HOOK_EMAIL_NOT_VERIFIED:
-					return hooks.trigger(VXPayPaymentHooksConfig.ON_EMAIL_NOT_VERIFIED, [message]);
+					return hooks.trigger(VXPayPaymentHooksConfig.ON_EMAIL_NOT_VERIFIED, [message], sourceTab);
 
 				case VXPayHookMessage.HOOK_PASSWORD_CHANGED:
-					return hooks.trigger(VXPayPaymentHooksConfig.ON_PASSWORD_CHANGED, [message]);
+					return hooks.trigger(VXPayPaymentHooksConfig.ON_PASSWORD_CHANGED, [message], sourceTab);
 			}
 	}
 };

--- a/test/Dom/Frame/VXPayPaymentTabTest.js
+++ b/test/Dom/Frame/VXPayPaymentTabTest.js
@@ -1,29 +1,31 @@
-import {assert}                from 'chai'
-import sinon                   from 'sinon'
-import {describe, it}          from 'mocha'
-import {given}                 from 'mocha-testdata'
-import VXPayPaymentTab         from './../../../src/VXPay/Dom/Frame/VXPayPaymentTab'
-import VXPayTestFx             from './../../Fixtures/VXPayTestFx'
-import VXPayConfig             from './../../../src/VXPay/VXPayConfig'
-import VXPayPaymentHooksConfig from './../../../src/VXPay/Config/VXPayPaymentHooksConfig'
-import VXPayLanguage           from './../../../src/VXPay/VXPayLanguage'
-import VXPayFlow               from './../../../src/VXPay/Config/VXPayFlow'
-import VXPayPaymentRoutes      from "../../../src/VXPay/Config/VXPayPaymentRoutes";
+import {assert}                   from 'chai';
+import sinon                      from 'sinon';
+import {describe, it, beforeEach} from 'mocha';
+import {given}                    from 'mocha-testdata';
+import VXPayPaymentTab            from './../../../src/VXPay/Dom/Frame/VXPayPaymentTab';
+import VXPayTestFx                from './../../Fixtures/VXPayTestFx';
+import VXPayConfig                from './../../../src/VXPay/VXPayConfig';
+import VXPayPaymentHooksConfig    from './../../../src/VXPay/Config/VXPayPaymentHooksConfig';
+import VXPayLanguage              from './../../../src/VXPay/VXPayLanguage';
+import VXPayFlow                  from './../../../src/VXPay/Config/VXPayFlow';
+import VXPayPaymentRoutes         from '../../../src/VXPay/Config/VXPayPaymentRoutes';
+import VXPayPaymentFrame          from '../../../src/VXPay/Dom/Frame/VXPayPaymentFrame';
 
 describe('VXPayPaymentTab', () => {
 
 	/** @var {VXPayPaymentTab} */
-	let tab,
-	    /** @var {VXPayConfig} */
-	    config,
-	    /** @var {Document} */
-	    doc;
+	let tab;
+
+	/** @var {VXPayConfig} */
+	let config;
+
+	/** @var {Document} */
+	let doc;
 
 	beforeEach(done => {
 		doc    = VXPayTestFx.getDocument();
 		config = new VXPayConfig(doc.defaultView);
-
-		tab = new VXPayPaymentTab(doc, 'test', config);
+		tab    = new VXPayPaymentTab(doc, 'test', config);
 		done();
 	});
 
@@ -36,7 +38,11 @@ describe('VXPayPaymentTab', () => {
 			assert.equal(tab.document, doc);
 			assert.equal(tab.name, 'test');
 			assert.isFalse(tab.loaded);
-		})
+		});
+		it('Should setup a communication frame when constructed', () => {
+			// check constructs communication tube
+			assert.instanceOf(tab._invisibleFrame, VXPayPaymentFrame);
+		});
 	});
 	describe('#sendOptions()', () => {
 		it('Should update the config', () => {
@@ -57,7 +63,7 @@ describe('VXPayPaymentTab', () => {
 
 			// cleanup
 			tab._config.merge.restore();
-		})
+		});
 	});
 	describe('#changeRoute', () => {
 		it('Changes route to default with no param', () => {
@@ -81,13 +87,14 @@ describe('VXPayPaymentTab', () => {
 
 			try {
 				tab.triggerLoad();
-			} catch (err) { /* ignore */ }
+			} catch (err) { /* ignore */
+			}
 		});
 		it('Should start listening for postMessage-s', done => {
 			const window = VXPayTestFx.getWindow();
 
 			// re-define functions to mock
-			tab.getNewTab = () => new Promise(resolve => resolve(window));
+			tab.getNewTab      = () => new Promise(resolve => resolve(window));
 			tab.startListening = (wnd) => {
 				assert.equal(wnd, window);
 				done();
@@ -95,7 +102,8 @@ describe('VXPayPaymentTab', () => {
 
 			try {
 				tab.triggerLoad();
-			} catch (err) { /* ignore */ }
+			} catch (err) { /* ignore */
+			}
 		});
 	});
 	describe('#getNewTab()', () => {
@@ -131,5 +139,5 @@ describe('VXPayPaymentTab', () => {
 				done();
 			});
 		});
-	})
+	});
 });


### PR DESCRIPTION
#### The problem:

- When the lib is loaded in mobile environment, the tab is opened and then user closes it - the tab wouldn't open again
- When the lib is loaded in mobile environment, and `isLoggedIn` action is triggered, it opens a tab, which shouldn't happen

#### The problem:
 - [x] Reset state of the `VXPay` each time close or success events are received
 - [x] Add a hidden iframe for cases with `enableTab` for post message communication
