### PR TITLE
Swap signup flow with login value + test

### DIFF
--- a/src/VXPay/Config/VXPayFlow.js
+++ b/src/VXPay/Config/VXPayFlow.js
@@ -36,7 +36,7 @@ class VXPayFlow {
 VXPayFlow.AVS             = 'avs';
 VXPayFlow.LIMIT           = 'limit';
 VXPayFlow.LOGIN           = 'login';
-VXPayFlow.SIGNUP          = 'signup';
+VXPayFlow.SIGNUP          = 'login';
 VXPayFlow.CHARGE          = 'moneycharge';
 VXPayFlow.OP_COMPENSATION = 'opcompensation';
 VXPayFlow.AUTO_RECHARGE   = 'autorecharge';

--- a/test/Middleware/Command/VXPayLoginTest.js
+++ b/test/Middleware/Command/VXPayLoginTest.js
@@ -1,0 +1,101 @@
+import {assert}                              from 'chai';
+import sinon                                 from 'sinon';
+import {describe, it, beforeEach, afterEach} from 'mocha';
+import VXPay                                 from './../../../src/VXPay';
+import VXPayConfig                           from './../../../src/VXPay/VXPayConfig';
+import VXPayTestFx                           from './../../Fixtures/VXPayTestFx';
+import VXPayLogin                            from '../../../src/VXPay/Middleware/Command/VXPayLogin';
+import VXPayPaymentFrame                     from '../../../src/VXPay/Dom/Frame/VXPayPaymentFrame';
+import VXPayLogger                           from '../../../src/VXPay/VXPayLogger';
+import VXPayFlow                             from '../../../src/VXPay/Config/VXPayFlow';
+import VXPayRoutes                           from '../../../src/VXPay/Config/VXPayRoutes';
+
+/**
+ * Fake duck-typed VXPay implementation
+ */
+class FakeVxPay {
+	constructor(pFrame) {
+		this._paymentFrame = pFrame;
+	}
+
+	get logger() {
+		return new VXPayLogger(true);
+	}
+
+	get config() {
+		return new VXPayConfig(VXPayTestFx.getWindow());
+	}
+
+	get paymentFrame() {
+		return new Promise((resolve) => {
+			resolve(this._paymentFrame);
+		});
+	}
+}
+
+describe('VXPayLogin', () => {
+	/** @var {VXPay} */
+	let vxpay;
+
+	const sandbox = sinon.createSandbox();
+
+	/** Setup VXPay object mock */
+	beforeEach(done => {
+		vxpay = new VXPay(new VXPayConfig(VXPayTestFx.getWindow()));
+
+		// fake frame
+		vxpay._paymentFrame = new VXPayPaymentFrame(
+			VXPayTestFx.getWindow().document,
+			'https://www.example.com',
+			'test',
+			vxpay._hooks
+		);
+
+		done();
+	});
+
+	afterEach(sandbox.restore);
+
+	describe('#open()', () => {
+		it('Should return a VXPay object', () => {
+			assert.instanceOf(VXPayLogin.open(vxpay), VXPay);
+		});
+		it('Should log open', () => {
+			sandbox.spy(vxpay._logger, 'log');
+
+			VXPayLogin.open(vxpay);
+			sandbox.assert.callCount(vxpay._logger.log, 4);
+			assert.equal('VXPayLogin::open()', vxpay._logger.log.getCall(0).args[0]);
+		});
+		it('Should send correct flow', () => {
+			// emulate frame loaded
+			const fakeVxPay = new FakeVxPay(vxpay._paymentFrame);
+
+			sandbox
+				.stub(vxpay._paymentFrame, 'sendUpdateParams')
+				.callsFake(function(params) {
+					// check same flow
+					assert.equal(params.flow, VXPayFlow.LOGIN);
+					return vxpay._paymentFrame;
+				});
+
+			sandbox
+				.stub(vxpay._paymentFrame, 'sendAdditionalOptions')
+				.returns(vxpay._paymentFrame);
+
+			sandbox
+				.stub(vxpay._paymentFrame, 'changeRoute')
+				.callsFake(function(route) {
+					assert.equal(route, VXPayRoutes.LOGIN);
+					return vxpay._paymentFrame
+				});
+
+			sandbox
+				.stub(vxpay._paymentFrame, 'initSession')
+				.returns(vxpay._paymentFrame);
+
+			// mock functions to be called
+			VXPayLogin.open(fakeVxPay);
+		});
+	});
+});

--- a/test/Middleware/Command/VXPaySignUpTest.js
+++ b/test/Middleware/Command/VXPaySignUpTest.js
@@ -1,0 +1,102 @@
+import {assert}                              from 'chai';
+import sinon                                 from 'sinon';
+import {describe, it, beforeEach, afterEach} from 'mocha';
+import VXPay                                 from './../../../src/VXPay';
+import VXPayConfig                           from './../../../src/VXPay/VXPayConfig';
+import VXPayTestFx                           from './../../Fixtures/VXPayTestFx';
+import VXPaySignUp                           from '../../../src/VXPay/Middleware/Command/VXPaySignUp';
+import VXPayPaymentFrame                     from '../../../src/VXPay/Dom/Frame/VXPayPaymentFrame';
+import VXPayLogger                           from '../../../src/VXPay/VXPayLogger';
+import VXPayFlow                             from '../../../src/VXPay/Config/VXPayFlow';
+import VXPayRoutes                           from '../../../src/VXPay/Config/VXPayRoutes';
+
+/**
+ * Fake duck-typed VXPay implementation
+ */
+class FakeVxPay {
+	constructor(pFrame) {
+		this._paymentFrame = pFrame;
+	}
+
+	get logger() {
+		return new VXPayLogger(true);
+	}
+
+	get config() {
+		return new VXPayConfig(VXPayTestFx.getWindow());
+	}
+
+	get paymentFrame() {
+		return new Promise((resolve) => {
+			resolve(this._paymentFrame);
+		});
+	}
+}
+
+describe('VXPaySignUp', () => {
+	/** @var {VXPay} */
+	let vxpay;
+
+	const sandbox = sinon.createSandbox();
+
+	/** Setup VXPay object mock */
+	beforeEach(done => {
+		vxpay = new VXPay(new VXPayConfig(VXPayTestFx.getWindow()));
+
+		// fake frame
+		vxpay._paymentFrame = new VXPayPaymentFrame(
+			VXPayTestFx.getWindow().document,
+			'https://www.example.com',
+			'test',
+			vxpay._hooks
+		);
+
+		done();
+	});
+
+	afterEach(sandbox.restore);
+
+	describe('#open()', () => {
+		it('Should return a VXPay object', () => {
+			assert.instanceOf(VXPaySignUp.open(vxpay), VXPay);
+		});
+		it('Should log open', () => {
+			sandbox.spy(vxpay._logger, 'log');
+
+			VXPaySignUp.open(vxpay);
+			sandbox.assert.callCount(vxpay._logger.log, 4);
+			assert.equal('VXPaySignUp::open()', vxpay._logger.log.getCall(0).args[0]);
+		});
+		it('Should send correct flow', () => {
+			// emulate frame loaded
+			const fakeVxPay = new FakeVxPay(vxpay._paymentFrame);
+
+			sandbox
+				.stub(vxpay._paymentFrame, 'sendUpdateParams')
+				.callsFake(function(params) {
+					// check same flow
+					assert.equal(params.flow, VXPayFlow.SIGNUP);
+					assert.equal(params.flow, VXPayFlow.LOGIN);
+					return vxpay._paymentFrame;
+				});
+
+			sandbox
+				.stub(vxpay._paymentFrame, 'sendAdditionalOptions')
+				.returns(vxpay._paymentFrame);
+
+			sandbox
+				.stub(vxpay._paymentFrame, 'changeRoute')
+				.callsFake(function(route) {
+					assert.equal(route, VXPayRoutes.SIGN_UP);
+					return vxpay._paymentFrame
+				});
+
+			sandbox
+				.stub(vxpay._paymentFrame, 'initSession')
+				.returns(vxpay._paymentFrame);
+
+			// mock functions to be called
+			VXPaySignUp.open(fakeVxPay);
+		});
+	});
+});


### PR DESCRIPTION
Addressing issue #23 

- Switch `signup` flow to be `login`
- Cover that with tests to prevent further unnoticed change