### PR TITLE
fix default setting of iFrame

### DIFF
--- a/src/VXPay/Dom/Frame/VXPayPaymentFrame.js
+++ b/src/VXPay/Dom/Frame/VXPayPaymentFrame.js
@@ -67,11 +67,10 @@ class VXPayPaymentFrame extends VXPayIframe {
 			width:      '100%',
 			height:     '100%',
 			top:        '50%',
-			left:       '50%',
-			marginLeft: '-325px',  // margin does not seem to be applied :/
-			zIndex:     10001,
-			display:    'none',
-			transform:  'translate(-50%, -50%)'
+			left:      '50%',
+			display:   'none',
+			transform: 'translate(-50%, -50%)',
+			zIndex:    '9999',
 		};
 
 		defaultStyles.position = userAgent.isMobile()
@@ -87,7 +86,6 @@ class VXPayPaymentFrame extends VXPayIframe {
 				defaultStyles.maxHeight = VXPayDomHelper.getClientHeight(document.defaultView) + 'px';
 			}
 		}
-
 		return defaultStyles;
 	}
 

--- a/src/VXPay/Dom/VXPayIframe.js
+++ b/src/VXPay/Dom/VXPayIframe.js
@@ -33,7 +33,7 @@ class VXPayIframe extends VXPayEventListener {
 		// only apply if valid
 		if (null !== style) {
 			for (let item in style) {
-				this._frame.style.setProperty(item, style[item]);
+				this._frame.style[item] = style[item];
 			}
 		}
 	}


### PR DESCRIPTION
#### The problem:
- Function .setproperty() in a constructor of VXPayIframe don't work with camelCase props.
