### PR TITLE
VXPayConfig - new platform parameter pfmsub

### DIFF
--- a/docs/vxpay.js
+++ b/docs/vxpay.js
@@ -2006,6 +2006,7 @@ function () {
         flow: this._flow,
         lang: this._language,
         pfm: this._pfm,
+        pfmsub: this._pfmsub,
         w: this._wmId,
         ws: this._wmSubRef,
         wt: this._wmToken,
@@ -2411,6 +2412,22 @@ function () {
     ,
     set: function set(value) {
       this._pfm = value;
+    }
+    /**
+     * @return {boolean}
+     */
+
+  }, {
+    key: "pfmsub",
+    get: function get() {
+      return this._pfmsub;
+    }
+    /**
+     * @param {string} value
+     */
+    ,
+    set: function set(value) {
+      this._pfmsub = value;
     }
     /**
      * @return {boolean}

--- a/src/VXPay/VXPayConfig.js
+++ b/src/VXPay/VXPayConfig.js
@@ -26,6 +26,7 @@ class VXPayConfig {
 		};
 
 		this._pfm        = '';
+		this._pfmsub     = '';
 		this._enableTab  = (new VXPayUserAgent(window.navigator.userAgent || '')).isMobile();
 		this._host       = '';
 		this._token      = '';
@@ -103,6 +104,7 @@ class VXPayConfig {
 			flow:        this._flow,
 			lang:        this._language,
 			pfm:         this._pfm,
+			pfmsub:      this._pfmsub,
 			w:           this._wmId,
 			ws:          this._wmSubRef,
 			wt:          this._wmToken,
@@ -408,6 +410,20 @@ class VXPayConfig {
 	 */
 	set pfm(value) {
 		this._pfm = value;
+	}
+
+	/**
+	 * @return {string}
+	 */
+	get pfmsub() {
+		return this._pfmsub;
+	}
+
+	/**
+	 * @param {string} value
+	 */
+	set pfmsub(value) {
+		this._pfmsub = value;
 	}
 
 	/**


### PR DESCRIPTION
Hi @t1gor,

we need to extend the VXPayConfig with a new parameters:

pfmsub = <string>

The behaviour should be exact the same like the pfm parameter:
  - new VXPayConfig parameter
  - the pfmsub parameter will be then part of the paytour url: 

e.g.:
...pfm=1502&pfmsub=h12361&..

https://github.com/VISIT-X/vxpay-js/blob/63a8c74e1b60dcc4d7bdb1dfb3d8583bf486ab99/src/VXPay/VXPayConfig.js#L28

Thank you,
PH