### PR TITLE
Add allow option for the iframe

### DIFF
--- a/src/VXPay/Dom/Frame/EnumAllow.js
+++ b/src/VXPay/Dom/Frame/EnumAllow.js
@@ -1,0 +1,14 @@
+const EnumAllow = {
+	MICROPHONE: 'microphone',
+	CAMERA:     'camera',
+
+	/**
+	 * @return {[string, string]}
+	 */
+	getDefaults: () => [
+		EnumAllow.CAMERA,
+		EnumAllow.MICROPHONE,
+	]
+};
+
+export default EnumAllow;

--- a/src/VXPay/Dom/Frame/VXPayPaymentFrame.js
+++ b/src/VXPay/Dom/Frame/VXPayPaymentFrame.js
@@ -7,6 +7,7 @@ import VXPayDomHelper           from './../VXPayDomHelper';
 import VXPayIsVisibleMessage    from './../../Message/VXPayIsVisibleMessage';
 import VXPayAdditionalOptions   from '../../Message/VXPayAdditionalOptions';
 import VXPayPaymentHooksConfig  from './../../Config/VXPayPaymentHooksConfig';
+import EnumAllow                from './EnumAllow';
 
 class VXPayPaymentFrame extends VXPayIframe {
 	/**
@@ -29,6 +30,10 @@ class VXPayPaymentFrame extends VXPayIframe {
 
 		// allow transparent iframe for <= IE8
 		this._frame.allowTransparency = true;
+
+		// allow camera and mic on the frame
+		this._frame.allow = EnumAllow.getDefaults().join(', ');
+
 		this._frame.name              = 'vxpay';
 		this._sessionInitialized      = false;
 		this._hooks                   = hooks;

--- a/test/Dom/Frame/EnumAllowTest.js
+++ b/test/Dom/Frame/EnumAllowTest.js
@@ -1,0 +1,14 @@
+import {describe, it} from 'mocha';
+import {assert}       from 'chai';
+import EnumAllow      from '../../../src/VXPay/Dom/Frame/EnumAllow';
+
+describe('EnumAllowTest', () => {
+	it('Should return default values as array', () => {
+		assert.isArray(EnumAllow.getDefaults());
+	});
+	it('Each of allow options should be strings', () => {
+		EnumAllow.getDefaults().forEach(option => {
+			assert.isString(option);
+		});
+	});
+});

--- a/test/Dom/Frame/VXPayPaymentFrameTest.js
+++ b/test/Dom/Frame/VXPayPaymentFrameTest.js
@@ -12,6 +12,7 @@ import VXPayChangeRouteMessage    from '../../../src/VXPay/Message/VXPayChangeRo
 import VXPayAdditionalOptions     from '../../../src/VXPay/Message/VXPayAdditionalOptions';
 import VXPayIsVisibleMessage      from '../../../src/VXPay/Message/VXPayIsVisibleMessage';
 import VXPayInitSessionMessage    from '../../../src/VXPay/Message/VXPayInitSessionMessage';
+import EnumAllow                  from '../../../src/VXPay/Dom/Frame/EnumAllow';
 
 describe('VXPayPaymentFrameTest', () => {
 
@@ -40,6 +41,21 @@ describe('VXPayPaymentFrameTest', () => {
 			hooks.onLoad(() => {
 				assert.isTrue(frame.loaded);
 				assert.equal(doc.getElementById(fid).length, 1);
+				done();
+			});
+			frame.triggerLoad();
+		});
+		it('Should set `allow` attribute with defaults (camera and mic)', () => {
+			assert.isFalse(frame.loaded);
+
+			// check before load
+			assert.equal(frame.frame.allow, EnumAllow.getDefaults().join(', '));
+
+			// and after load
+			hooks.onLoad(() => {
+				assert.isTrue(frame.loaded);
+				assert.equal(doc.getElementById(fid).length, 1);
+				assert.equal(doc.getElementById(fid).allow, EnumAllow.getDefaults().join(', '));
 				done();
 			});
 			frame.triggerLoad();


### PR DESCRIPTION
As per @stha's request:

- add `allow` attributes for the injected iframe
- set default allow to `camera, microphone`