### PR TITLE
VXPaySuccessMessage - add user services field

### DIFF
--- a/src/VXPay/Config/VXPayUser.js
+++ b/src/VXPay/Config/VXPayUser.js
@@ -5,6 +5,7 @@ class VXPayUser {
 		this._nickname = '';
 		this._userId   = NaN;
 		this._uhash    = '';
+		this._services = {};
 	}
 
 	/**
@@ -75,6 +76,20 @@ class VXPayUser {
 	 */
 	set uhash(value) {
 		this._uhash = value;
+	}
+
+	/**
+	 * @return {Object}
+	 */
+	get services() {
+		return this._services;
+	}
+
+	/**
+	 * @param {Object} value
+	 */
+	set services(value) {
+		this._services = value;
 	}
 }
 

--- a/src/VXPay/Message/VXPaySuccessMessage.js
+++ b/src/VXPay/Message/VXPaySuccessMessage.js
@@ -15,6 +15,7 @@ class VXPaySuccessMessage extends VXPayMessage {
 		this.user.fsk18    = data.fsk18 || false;
 		this.user.userId   = data.userId || NaN;
 		this.user.uhash    = data.uhash || '';
+		this.user.services = data.services || {};
 	}
 }
 
@@ -34,7 +35,8 @@ VXPaySuccessMessage.USER_DATA_STRUCT = {
 	'transferToken':  'TT_7a9523c9-5555-4c48-5555-91cc2465f484',
 	'availableMoney': 12.34,
 	'fsk18':          false,
-	'uhash':          ''
+	'uhash':          '',
+	'services':       {},
 };
 
 export default VXPaySuccessMessage;

--- a/test/Message/VXPaySuccessMessageTest.js
+++ b/test/Message/VXPaySuccessMessageTest.js
@@ -19,5 +19,14 @@ describe('VXPaySuccessMessage', () => {
 			assert.equal(12.55, successMessage.user.balance);
 			assert.equal('', successMessage.user.uhash);
 		});
+		it('`services` unset', () => {
+			const successMessage = new VXPaySuccessMessage();
+			assert.notStrictEqual({}, successMessage.user.services);
+		});
+		it('`services` should have consistent type', () => {
+			const data = {services: {telegram: {token: 'xxx'}}};
+			const successMessage = new VXPaySuccessMessage(data);
+			assert.equal(data.services, successMessage.user.services);
+		});
 	});
 });


### PR DESCRIPTION
#### The problem:

- the backend should provide services info for the frontend
- VXPaySuccessMessage needs to be extended to contain this info

#### The solution:

- extend the class with the info
