### PR TITLE
fix iframe allow property for firefox

### DIFF
--- a/src/VXPay/Dom/Frame/VXPayPaymentFrame.js
+++ b/src/VXPay/Dom/Frame/VXPayPaymentFrame.js
@@ -32,7 +32,10 @@ class VXPayPaymentFrame extends VXPayIframe {
 		this._frame.allowTransparency = true;
 
 		// allow camera and mic on the frame
-		this._frame.allow = EnumAllow.getDefaults().join(', ');
+		this._frame.allow = EnumAllow.getDefaults().join('; ');
+
+		// fullscreen
+		this._frame.allowfullscreen = '';
 
 		this._frame.name              = 'vxpay';
 		this._sessionInitialized      = false;


### PR DESCRIPTION
#### The problem:

- in a nested iframe in the paytour, there's an error in Firefox, when trying to access camera and microphone

#### The solution:

- correct allow property should solve this