### PR TITLE
fix self accessor in commands

### DIFF
--- a/src/VXPay/Middleware/Command/VXPayAVS.js
+++ b/src/VXPay/Middleware/Command/VXPayAVS.js
@@ -19,7 +19,7 @@ export default class VXPayAVS {
 
 		vxpay.paymentFrame.then(frame => frame
 			.initSession()
-			.sendOptions(Object.assign({}, self.defaultFlowOptions(), flowOptions))
+			.sendOptions(Object.assign({}, VXPayAVS.defaultFlowOptions(), flowOptions))
 			.sendAdditionalOptions(vxpay.config.getAdditionalOptions())
 			.changeRoute(VXPayRoutes.AVS)
 		);

--- a/src/VXPay/Middleware/Command/VXPayAbo.js
+++ b/src/VXPay/Middleware/Command/VXPayAbo.js
@@ -18,7 +18,7 @@ export default class VXPayAbo {
 		vxpay.logger.log('VXPayAbo::open()');
 
 		vxpay.paymentFrame.then(frame => frame
-			.sendOptions(Object.assign({}, self.defaultFlowOptions(), flowOptions))
+			.sendOptions(Object.assign({}, VXPayAbo.defaultFlowOptions(), flowOptions))
 			.sendAdditionalOptions(vxpay.config.getAdditionalOptions())
 			.changeRoute(VXPayRoutes.ABO)
 			.initSession()

--- a/src/VXPay/Middleware/Command/VXPayAboOverview.js
+++ b/src/VXPay/Middleware/Command/VXPayAboOverview.js
@@ -18,7 +18,7 @@ export default class VXPayAboOverview {
 		vxpay.logger.log('VXPayAboOverview::open()');
 
 		vxpay.paymentFrame.then(frame => frame
-			.sendOptions(Object.assign({}, self.defaultFlowOptions(), flowOptions))
+			.sendOptions(Object.assign({}, VXPayAboOverview.defaultFlowOptions(), flowOptions))
 			.sendAdditionalOptions(vxpay.config.getAdditionalOptions())
 			.changeRoute(VXPayRoutes.ABO_OVERVIEW)
 			.initSession()

--- a/src/VXPay/Middleware/Command/VXPayAutoRecharge.js
+++ b/src/VXPay/Middleware/Command/VXPayAutoRecharge.js
@@ -24,7 +24,7 @@ class VXPayAutoRecharge {
 
 		vxpay.paymentFrame.then(frame => frame
 			.initSession()
-			.sendOptions(Object.assign({}, self.defaultFlowOptions(), flowOptions))
+			.sendOptions(Object.assign({}, VXPayAutoRecharge.defaultFlowOptions(), flowOptions))
 			.sendAdditionalOptions(vxpay.config.getAdditionalOptions())
 			.changeRoute(VXPayRoutes.RECHARGE)
 		);

--- a/src/VXPay/Middleware/Command/VXPayLimitedPayment.js
+++ b/src/VXPay/Middleware/Command/VXPayLimitedPayment.js
@@ -20,7 +20,7 @@ class VXPayLimitedPayment {
 		vxpay.logger.log('VXPayLimitedPayment()');
 
 		vxpay.paymentFrame.then(frame => frame
-			.sendOptions(self.defaultFlowOptions())
+			.sendOptions(VXPayLimitedPayment.defaultFlowOptions())
 			.sendAdditionalOptions(vxpay.config.getAdditionalOptions())
 			.changeRoute(VXPayRoutes.LIMIT)
 			.initSession()

--- a/src/VXPay/Middleware/Command/VXPayLogin.js
+++ b/src/VXPay/Middleware/Command/VXPayLogin.js
@@ -18,7 +18,7 @@ export default class VXPayLogin {
 		vxpay.logger.log('VXPayLogin::open()');
 
 		vxpay.paymentFrame.then(frame => frame
-			.sendOptions(Object.assign({}, self.defaultFlowOptions(), flowOptions))
+			.sendOptions(Object.assign({}, VXPayLogin.defaultFlowOptions(), flowOptions))
 			.sendAdditionalOptions(vxpay.config.getAdditionalOptions())
 			.changeRoute(VXPayRoutes.LOGIN)
 			.initSession()

--- a/src/VXPay/Middleware/Command/VXPayLostPassword.js
+++ b/src/VXPay/Middleware/Command/VXPayLostPassword.js
@@ -26,7 +26,7 @@ export default class VXPayLostPassword {
 	static run(vxpay, flowOptions = {}) {
 		vxpay.logger.log('VXPayLostPassword()');
 
-		const options = Object.assign({}, self.defaultFlowOptions(vxpay.config), flowOptions);
+		const options = Object.assign({}, VXPayLostPassword.defaultFlowOptions(vxpay.config), flowOptions);
 
 		vxpay.paymentFrame.then(frame => frame
 			.initSession()

--- a/src/VXPay/Middleware/Command/VXPayMigration.js
+++ b/src/VXPay/Middleware/Command/VXPayMigration.js
@@ -19,7 +19,7 @@ export default class VXPayMigration {
 
 		vxpay.paymentFrame
 			.then(frame => frame
-				.sendUpdateParams(Object.assign({}, self.defaultFlowOptions(), flowOptions))
+				.sendUpdateParams(Object.assign({}, VXPayMigration.defaultFlowOptions(), flowOptions))
 				.sendAdditionalOptions(vxpay.config.getAdditionalOptions())
 				.changeRoute(VXPayRoutes.MIGRATION)
 				.initSession()

--- a/src/VXPay/Middleware/Command/VXPayOneClick.js
+++ b/src/VXPay/Middleware/Command/VXPayOneClick.js
@@ -25,7 +25,7 @@ class VXPayOneClick {
 
 		vxpay.paymentFrame.then(frame => frame
 			.initSession()
-			.sendOptions(Object.assign({}, self.defaultFlowOptions(), flowOptions))
+			.sendOptions(Object.assign({}, VXPayOneClick.defaultFlowOptions(), flowOptions))
 			.sendAdditionalOptions(vxpay.config.getAdditionalOptions())
 			.changeRoute(VXPayRoutes.ONE_CLICK)
 		);

--- a/src/VXPay/Middleware/Command/VXPayOpenBalance.js
+++ b/src/VXPay/Middleware/Command/VXPayOpenBalance.js
@@ -19,7 +19,7 @@ export default class VXPayOpenBalance {
 
 		vxpay.paymentFrame.then(frame => frame
 			.initSession()
-			.sendOptions(Object.assign({}, self.defaultFlowOptions(), flowOptions))
+			.sendOptions(Object.assign({}, VXPayOpenBalance.defaultFlowOptions(), flowOptions))
 			.sendAdditionalOptions(vxpay.config.getAdditionalOptions())
 			.changeRoute(VXPayRoutes.OP_COMP)
 		);

--- a/src/VXPay/Middleware/Command/VXPayPayment.js
+++ b/src/VXPay/Middleware/Command/VXPayPayment.js
@@ -21,7 +21,7 @@ class VXPayPayment {
 		vxpay.logger.log('VXPayPayment()');
 
 		vxpay.paymentFrame.then(frame => frame
-			.sendOptions(Object.assign({}, self.defaultFlowOptions(), flowOptions))
+			.sendOptions(Object.assign({}, VXPayPayment.defaultFlowOptions(), flowOptions))
 			.sendAdditionalOptions(vxpay.config.getAdditionalOptions())
 			.changeRoute(VXPayRoutes.PAYMENT)
 			.initSession()

--- a/src/VXPay/Middleware/Command/VXPayPremiumAbo.js
+++ b/src/VXPay/Middleware/Command/VXPayPremiumAbo.js
@@ -19,7 +19,7 @@ export default class VXPayPremiumAbo {
 
 		vxpay.paymentFrame.then(frame => frame
 			.initSession()
-			.sendOptions(Object.assign({}, self.defaultFlowOptions(), flowOptions))
+			.sendOptions(Object.assign({}, VXPayPremiumAbo.defaultFlowOptions(), flowOptions))
 			.sendAdditionalOptions(vxpay.config.getAdditionalOptions())
 			.changeRoute(VXPayRoutes.ABO)
 		);

--- a/src/VXPay/Middleware/Command/VXPayPromoCode.js
+++ b/src/VXPay/Middleware/Command/VXPayPromoCode.js
@@ -19,7 +19,7 @@ export default class VXPayPromoCode {
 
 		vxpay.paymentFrame.then(frame => frame
 			.initSession()
-			.sendOptions(Object.assign({}, self.defaultFlowOptions(), flowOptions))
+			.sendOptions(Object.assign({}, VXPayPromoCode.defaultFlowOptions(), flowOptions))
 			.sendAdditionalOptions(vxpay.config.getAdditionalOptions())
 			.changeRoute(VXPayRoutes.PROMOCODE)
 		);

--- a/src/VXPay/Middleware/Command/VXPayResetPassword.js
+++ b/src/VXPay/Middleware/Command/VXPayResetPassword.js
@@ -26,7 +26,7 @@ export default class VXPayResetPassword {
 	static run(vxpay, flowOptions = {}) {
 		vxpay.logger.log('VXPayResetPassword()');
 
-		const options = Object.assign({}, self.defaultFlowOptions(vxpay.config), flowOptions);
+		const options = Object.assign({}, VXPayResetPassword.defaultFlowOptions(vxpay.config), flowOptions);
 
 		vxpay.paymentFrame.then(frame => frame
 			.initSession()

--- a/src/VXPay/Middleware/Command/VXPaySettings.js
+++ b/src/VXPay/Middleware/Command/VXPaySettings.js
@@ -20,7 +20,7 @@ class VXPaySettings {
 		vxpay.logger.log('VXPaySettings()');
 
 		vxpay.paymentFrame.then(frame => frame
-			.sendOptions(self.defaultFlowOptions())
+			.sendOptions(VXPaySettings.defaultFlowOptions())
 			.sendAdditionalOptions(vxpay.config.getAdditionalOptions())
 			.changeRoute(VXPayRoutes.SETTINGS)
 			.initSession()

--- a/src/VXPay/Middleware/Command/VXPaySignUp.js
+++ b/src/VXPay/Middleware/Command/VXPaySignUp.js
@@ -19,7 +19,7 @@ export default class VXPaySignUp {
 
 		vxpay.paymentFrame
 			.then(frame => frame
-				.sendUpdateParams(Object.assign({}, self.defaultFlowOptions(), flowOptions))
+				.sendUpdateParams(Object.assign({}, VXPaySignUp.defaultFlowOptions(), flowOptions))
 				.sendAdditionalOptions(vxpay.config.getAdditionalOptions())
 				.changeRoute(VXPayRoutes.SIGN_UP)
 				.initSession()

--- a/src/VXPay/Middleware/Command/VXPayTelegram.js
+++ b/src/VXPay/Middleware/Command/VXPayTelegram.js
@@ -19,7 +19,7 @@ export default class VXPayTelegram {
 
 		vxpay.paymentFrame
 			.then(frame => frame
-				.sendUpdateParams(Object.assign({}, self.defaultFlowOptions(), flowOptions))
+				.sendUpdateParams(Object.assign({}, VXPayTelegram.defaultFlowOptions(), flowOptions))
 				.sendAdditionalOptions(vxpay.config.getAdditionalOptions())
 				.changeRoute(VXPayRoutes.TELEGRAM)
 				.initSession()

--- a/src/VXPay/Middleware/Command/VXPayVipAboTrial.js
+++ b/src/VXPay/Middleware/Command/VXPayVipAboTrial.js
@@ -19,7 +19,7 @@ export default class VXPayVipAboTrial {
 
 		vxpay.paymentFrame.then(frame => frame
 			.initSession()
-			.sendOptions(Object.assign({}, self.defaultFlowOptions(), flowOptions))
+			.sendOptions(Object.assign({}, VXPayVipAboTrial.defaultFlowOptions(), flowOptions))
 			.sendAdditionalOptions(vxpay.config.getAdditionalOptions())
 			.changeRoute(VXPayRoutes.ABO)
 		);

--- a/src/VXPay/Middleware/Command/VXPayVoiceCall.js
+++ b/src/VXPay/Middleware/Command/VXPayVoiceCall.js
@@ -21,7 +21,7 @@ class VXPayVoiceCall {
 		vxpay.logger.log('VXPayVoiceCall::reset()');
 
 		vxpay.paymentFrame.then(frame => frame
-			.sendOptions(self.defaultFlowOptions())
+			.sendOptions(VXPayVoiceCall.defaultFlowOptions())
 			.sendAdditionalOptions(vxpay.config.getAdditionalOptions())
 			.changeRoute(VXPayRoutes.VOICE_CALL)
 			.initSession()


### PR DESCRIPTION
#### The problem:

- self static accessor is used in the code, which has no native support in some browsers and is not transpiled

self.defaultOptions()

#### The solution:

- replace all occurences with the class name

VXPayPayment.defaultOptions()
